### PR TITLE
Fix paths and scope figures to proper namespace

### DIFF
--- a/bin/run.rb
+++ b/bin/run.rb
@@ -1,10 +1,11 @@
 #!/usr/bin/env ruby
 
-Dir['../lib/figure/*.rb'].each { |file| require file }
+require_relative '../lib/figure'
+
 # print Knight.new('g2').possible_moves
 # print King.new('g2').possible_moves
 # print Rook.new('g2').vectors
 # print Bishop.new('g2').possible_moves
 # print PawnWhite.new('g2').possible_moves
 # print PawnBlack.new('g7').possible_moves
-print Queen.new('g2').possible_moves
+print Figure::Queen.new('g2').possible_moves

--- a/lib/figure.rb
+++ b/lib/figure.rb
@@ -1,4 +1,11 @@
-Dir['/lib/figure/*.rb'].each { |file| require file }
-# Dupa dupa
+require_relative 'figure/base'
+require_relative 'figure/bishop'
+require_relative 'figure/king'
+require_relative 'figure/knight'
+require_relative 'figure/pawn_black'
+require_relative 'figure/pawn_white'
+require_relative 'figure/queen'
+require_relative 'figure/rook'
+
 module Figure
 end

--- a/lib/figure/base.rb
+++ b/lib/figure/base.rb
@@ -1,37 +1,39 @@
-# This class describes the exchange from input to output
-class Base
-  attr_reader :x, :y
-  def initialize(move)
-    @x = letters.index(move[0])
-    @y = move[1].to_i
-  end
+module Figure
+  # This class describes the exchange from input to output
+  class Base
+    attr_reader :x, :y
+    def initialize(move)
+      @x = letters.index(move[0])
+      @y = move[1].to_i
+    end
 
-  def possible_moves
-    moves.map { |out_x, out_y| "#{letters[out_x]}#{out_y}" }
-  end
+    def possible_moves
+      moves.map { |out_x, out_y| "#{letters[out_x]}#{out_y}" }
+    end
 
-  private_class_method
-  def all_moves
-    vectors.map { |wx, wy| [wx + x, wy + y] }
-  end
+    private_class_method
+    def all_moves
+      vectors.map { |wx, wy| [wx + x, wy + y] }
+    end
 
-  def onboard(position)
-    range.include?(position)
-  end
+    def onboard(position)
+      range.include?(position)
+    end
 
-  def range
-    Range.new(1, 8)
-  end
+    def range
+      Range.new(1, 8)
+    end
 
-  def moves
-    all_moves.sort.select { |mx, my| onboard(mx) && onboard(my) }
-  end
+    def moves
+      all_moves.sort.select { |mx, my| onboard(mx) && onboard(my) }
+    end
 
-  def letters
-    ' abcdefgh'
-  end
+    def letters
+      ' abcdefgh'
+    end
 
-  def vectors
-    self.class.vectors
+    def vectors
+      self.class.vectors
+    end
   end
 end

--- a/lib/figure/bishop.rb
+++ b/lib/figure/bishop.rb
@@ -1,9 +1,11 @@
-# Vectors move bishop
-class Bishop < Base
-  private_class_method
-  def self.vectors
-    ((-7..-1).to_a + (1..7).to_a).flat_map do |i|
-      [[i, i], [i, -i]]
+module Figure
+  # Vectors move bishop
+  class Bishop < Base
+    private_class_method
+    def self.vectors
+      ((-7..-1).to_a + (1..7).to_a).flat_map do |i|
+        [[i, i], [i, -i]]
+      end
     end
   end
 end

--- a/lib/figure/king.rb
+++ b/lib/figure/king.rb
@@ -1,7 +1,9 @@
-# Vectors move King
-class King < Base
-  private_class_method
-  def self.vectors
-    [[-1, 1], [-1, 0], [-1, -1], [0, 1], [0, -1], [1, 1], [1, 0], [1, -1]]
+module Figure
+  # Vectors move King
+  class King < Base
+    private_class_method
+    def self.vectors
+      [[-1, 1], [-1, 0], [-1, -1], [0, 1], [0, -1], [1, 1], [1, 0], [1, -1]]
+    end
   end
 end

--- a/lib/figure/knight.rb
+++ b/lib/figure/knight.rb
@@ -1,7 +1,9 @@
-# Vectors move Knight
-class Knight < Base
-  private_class_method
-  def self.vectors
-    [[-1, 2], [1, 2], [-1, -2], [1, -2], [-2, 1], [-2, -1], [2, 1], [2, -1]]
+module Figure
+  # Vectors move Knight
+  class Knight < Base
+    private_class_method
+    def self.vectors
+      [[-1, 2], [1, 2], [-1, -2], [1, -2], [-2, 1], [-2, -1], [2, 1], [2, -1]]
+    end
   end
 end

--- a/lib/figure/pawn_black.rb
+++ b/lib/figure/pawn_black.rb
@@ -1,15 +1,17 @@
-# Vectors move Pawn
-class PawnBlack < Base
-  private_class_method
-  def vectors
-    pawn_position
-  end
+module Figure
+  # Vectors move Pawn
+  class PawnBlack < Base
+    private_class_method
+    def vectors
+      pawn_position
+    end
 
-  def pawn_position
-    if y == 7
-      [[0, -2], [0, -1]]
-    else
-      [[0, -1]]
+    def pawn_position
+      if y == 7
+        [[0, -2], [0, -1]]
+      else
+        [[0, -1]]
+      end
     end
   end
 end

--- a/lib/figure/pawn_white.rb
+++ b/lib/figure/pawn_white.rb
@@ -1,15 +1,17 @@
-# Vectors move Pawn
-class PawnWhite < Base
-  private_class_method
-  def vectors
-    pawn_position
-  end
+module Figure
+  # Vectors move Pawn
+  class PawnWhite < Base
+    private_class_method
+    def vectors
+      pawn_position
+    end
 
-  def pawn_position
-    if y == 2
-      [[0, 2], [0, 1]]
-    else
-      [[0, 1]]
+    def pawn_position
+      if y == 2
+        [[0, 2], [0, 1]]
+      else
+        [[0, 1]]
+      end
     end
   end
 end

--- a/lib/figure/queen.rb
+++ b/lib/figure/queen.rb
@@ -1,10 +1,9 @@
-require_relative 'base'
-require_relative 'bishop'
-require_relative 'rook'
-# Vectors move Queen
-class Queen < Base
-  private_class_method
-  def self.vectors
-    Rook.vectors + Bishop.vectors
+module Figure
+  # Vectors move Queen
+  class Queen < Base
+    private_class_method
+    def self.vectors
+      Rook.vectors + Bishop.vectors
+    end
   end
 end

--- a/lib/figure/rook.rb
+++ b/lib/figure/rook.rb
@@ -1,9 +1,11 @@
-# Vectors move bishop
-class Rook < Base
-  # private_class_method
-  def self.vectors
-    ((-7..-1).to_a + (1..7).to_a).flat_map do |i|
-      [[i, 0], [0, i]]
+module Figure
+  # Vectors move bishop
+  class Rook < Base
+    # private_class_method
+    def self.vectors
+      ((-7..-1).to_a + (1..7).to_a).flat_map do |i|
+        [[i, 0], [0, i]]
+      end
     end
   end
 end


### PR DESCRIPTION
- Figures under `lib/figures/` should be placed in `Figure` namespace
- It's quite conventional in Ruby to require each file separately in places like our `lib/figure.rb`, and using `Dir['/lib/figure/*.rb']` is not quite a good solution here, because:
  - We have to load`base.rb` file first to make others work (order matters), and
  - `Dir` depends on from which directory we execute the file containing it (your program would work differently if you had run it from `root` directory, and differently if from e.g. `/lib` directory)
